### PR TITLE
Интегрировать Chip в SearchScreen с правильным позиционированием и состояниями

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/app/di/DataModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/app/di/DataModule.kt
@@ -2,13 +2,15 @@ package ru.practicum.android.diploma.app.di
 
 import okhttp3.OkHttpClient
 import org.koin.dsl.module
-import ru.practicum.android.diploma.feature.search.data.repository.VacancyRepositoryImpl
-import ru.practicum.android.diploma.feature.search.domain.repository.VacancyRepository
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import ru.practicum.android.diploma.BuildConfig
 import ru.practicum.android.diploma.core.config.ApiConfig
 import ru.practicum.android.diploma.core.data.network.api.VacancyApi
+import ru.practicum.android.diploma.core.data.network.client.NetworkClient
+import ru.practicum.android.diploma.core.data.network.client.RetrofitNetworkClient
+import ru.practicum.android.diploma.feature.search.data.repository.VacancyRepositoryImpl
+import ru.practicum.android.diploma.feature.search.domain.repository.VacancyRepository
 
 /**
  * Модуль Koin, отвечающий за зависимости Repository и Data sources
@@ -43,9 +45,15 @@ val dataModule = module {
         get<Retrofit>().create(VacancyApi::class.java)
     }
 
+    single<NetworkClient> {
+        RetrofitNetworkClient(
+            get<VacancyApi>()
+        )
+    }
+
     single<VacancyRepository> {
         VacancyRepositoryImpl(
-            networkClient = get(),
+            get<NetworkClient>(),
         )
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/app/di/DomainModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/app/di/DomainModule.kt
@@ -1,9 +1,9 @@
 package ru.practicum.android.diploma.app.di
 
 import org.koin.dsl.module
-import ru.practicum.android.diploma.feature.vacancy.domain.VacancyInteractor
 import ru.practicum.android.diploma.feature.search.domain.interactor.SearchInteractor
 import ru.practicum.android.diploma.feature.search.domain.interactor.SearchInteractorImpl
+import ru.practicum.android.diploma.feature.vacancy.domain.VacancyInteractor
 
 /**
  * Модуль Koin, отвечающий за зависимости Interactor/Usecases

--- a/app/src/main/java/ru/practicum/android/diploma/app/di/PresentationModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/app/di/PresentationModule.kt
@@ -3,6 +3,8 @@ package ru.practicum.android.diploma.app.di
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import ru.practicum.android.diploma.app.navigation.NavigationViewModel
+import ru.practicum.android.diploma.feature.search.domain.repository.VacancyRepository
+import ru.practicum.android.diploma.feature.search.ui.SearchViewModel
 import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyViewModel
 
 /**
@@ -18,6 +20,12 @@ val presentationModule = module {
         VacancyViewModel(
             interactor = get(),
             vacancyId = vacancyId
+        )
+    }
+
+    viewModel<SearchViewModel> {
+        SearchViewModel(
+            get<VacancyRepository>()
         )
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/app/ui/theme/AppDimensions.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/app/ui/theme/AppDimensions.kt
@@ -21,7 +21,6 @@ object AppDimensions {
     }
 
     object Chip {
-        val cornerRadius = 12.dp
         val contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp)
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/Chip.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/Chip.kt
@@ -3,7 +3,8 @@ package ru.practicum.android.diploma.feature.search.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +23,8 @@ fun Chip(
 ) {
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(AppDimensions.Chip.cornerRadius))
+            .wrapContentSize()
+            .clip(CircleShape)
             .background(MaterialTheme.colorScheme.primary),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchScreen.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchScreen.kt
@@ -1,10 +1,8 @@
 package ru.practicum.android.diploma.feature.search.ui
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -13,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -29,53 +28,74 @@ fun SearchScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
-        topBar = { SearchTopBar() }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize()
-        ) {
-            // Поиск
+        topBar = {
+            SearchTopBar()
             SearchBar(
                 text = state.searchText,
                 isClearVisible = state.isClearTextVisible,
                 onTextChange = viewModel::onSearchTextChanged,
                 onClearClick = viewModel::onClearTextClicked
             )
+        }
+    ) { paddingValues ->
+        val chipText = getChipText(state.vacancyState)
 
-            Spacer(modifier = Modifier.height(8.dp))
+        Box(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            // Контент: список или плейсхолдер
+            when (val stateContent = state.vacancyState) {
+                VacancyState.Loading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
 
-            // Chip — всегда под поиском
-            val vacanciesCount = (state.vacancyState as? VacancyState.Content)?.vacancies?.size ?: 0
-            val chipText = if (vacanciesCount > 0) {
-                pluralStringResource(R.plurals.vacancies_found, vacanciesCount, vacanciesCount)
-            } else {
-                stringResource(R.string.no_vacancies_found)
+                is VacancyState.Content -> VacancyList(
+                    vacancies = stateContent.vacancies,
+                    onVacancyClick = onVacancyClick,
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                VacancyState.Idle -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Image(
+                            painter = painterResource(R.drawable.ic_search_screen),
+                            contentDescription = null
+                        )
+                    }
+                }
+
+                VacancyState.Empty -> NotFoundPlaceholder(modifier = Modifier.fillMaxSize())
+
+                VacancyState.ErrorInternet -> NoInternetPlaceholder(modifier = Modifier.fillMaxSize())
+
+                VacancyState.ErrorFound -> NotFoundPlaceholder(modifier = Modifier.fillMaxSize())
             }
 
-            Chip(text = chipText)
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Контент: список или плейсхолдер
-            Box(modifier = Modifier.fillMaxSize()) {
-                when (val stateContent = state.vacancyState) {
-                    VacancyState.Loading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-
-                    is VacancyState.Content -> VacancyList(
-                        vacancies = stateContent.vacancies,
-                        onVacancyClick = onVacancyClick,
-                        modifier = Modifier.fillMaxSize()
-                    )
-
-                    VacancyState.Empty -> NotFoundPlaceholder(modifier = Modifier.fillMaxSize())
-
-                    VacancyState.ErrorInternet -> NoInternetPlaceholder(modifier = Modifier.fillMaxSize())
-
-                    VacancyState.ErrorFound -> NotFoundPlaceholder(modifier = Modifier.fillMaxSize())
-                }
+            chipText?.let { text ->
+                Chip(
+                    text = text,
+                    modifier = Modifier.padding(4.dp)
+                )
             }
         }
     }
+}
+
+@Composable
+private fun getChipText(vacancyState: VacancyState): String? = when (vacancyState) {
+    is VacancyState.Content -> {
+        val vacanciesCount = vacancyState.vacancies.size
+        pluralStringResource(R.plurals.vacancies_found, vacanciesCount, vacanciesCount)
+    }
+
+    is VacancyState.Empty -> stringResource(R.string.no_vacancies_found)
+
+    VacancyState.ErrorFound,
+    VacancyState.ErrorInternet,
+    VacancyState.Loading,
+    VacancyState.Idle -> null
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchScreenPreview.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchScreenPreview.kt
@@ -73,6 +73,7 @@ fun SearchScreenPreview(
 
                     VacancyState.ErrorInternet -> NoInternetPlaceholder()
                     VacancyState.ErrorFound -> NotFoundPlaceholder()
+                    VacancyState.Idle -> {}
                 }
             }
         }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchUiState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/SearchUiState.kt
@@ -2,6 +2,6 @@ package ru.practicum.android.diploma.feature.search.ui
 
 data class SearchUiState(
     val searchText: String = "",
-    val vacancyState: VacancyState = VacancyState.Empty,
+    val vacancyState: VacancyState = VacancyState.Idle,
     val isClearTextVisible: Boolean = false,
 )

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/VacancyList.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/VacancyList.kt
@@ -1,10 +1,12 @@
 package ru.practicum.android.diploma.feature.search.ui
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import ru.practicum.android.diploma.core.domain.model.Vacancy
 import ru.practicum.android.diploma.core.presentation.components.VacancyItem
 import ru.practicum.android.diploma.core.presentation.model.VacancyItemData
@@ -17,7 +19,8 @@ fun VacancyList(
     onVacancyClick: (Vacancy) -> Unit
 ) {
     LazyColumn(
-        modifier = modifier
+        modifier = modifier,
+        contentPadding = PaddingValues(top = 38.dp)
     ) {
         items(
             items = vacancies,

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/VacancyState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/ui/VacancyState.kt
@@ -3,6 +3,7 @@ package ru.practicum.android.diploma.feature.search.ui
 import ru.practicum.android.diploma.core.domain.model.Vacancy
 
 sealed interface VacancyState {
+    data object Idle : VacancyState
     object Loading : VacancyState
     object ErrorInternet : VacancyState
     object ErrorFound : VacancyState


### PR DESCRIPTION
**Рефакторинг Chip**
- Изменена форма чипа с RoundedCornerShape на CircleShape для соответствия дизайну
- Удален неиспользуемый параметр cornerRadius из AppDimensions.Chip
- Добавлен wrapContentSize для правильного размера

**SearchScreen**
- Переработана структура экрана: Chip теперь накладывается поверх контента через Box
- Chip отображается только в состояниях Content и Empty, скрыт при Loading, Error и Idle
- Добавлено начальное состояние VacancyState.Idle для пустого экрана без поиска
- Изменен отступ списка вакансий (top = 38.dp) для правильного позиционирования под Chip
- Вместо Column с фиксированными отступами используется Box с выравниванием по верхнему краю

**Состояния**
- Добавлено VacancyState.Idle для отображения заглушки поиска (иконка поиска)
- Начальное состояние SearchUiState изменено с Empty на Idle
- В превью добавлена обработка Idle состояния

**Сетевой слой**
- Добавлен NetworkClient и RetrofitNetworkClient для инкапсуляции сетевых запросов
- Обновлены DI-модули для использования NetworkClient вместо прямого вызова VacancyApi
- Добавлен SearchViewModel в PresentationModule

**Результат**
- Чип теперь корректно отображается только при наличии результатов поиска или при пустом результате
- Устранены лишние отступы, Chip накладывается поверх списка
- Логика состояний экрана поиска стала более прозрачной и предсказуемой