### PR TITLE
feature/new_filter_area_model

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/core/data/network/dto/FilterAreaDto.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/core/data/network/dto/FilterAreaDto.kt
@@ -1,6 +1,7 @@
 package ru.practicum.android.diploma.core.data.network.dto
 
 import ru.practicum.android.diploma.core.domain.model.FilterArea
+import ru.practicum.android.diploma.core.domain.model.GeoArea
 
 data class FilterAreaDto(
     val id: Int,
@@ -9,9 +10,28 @@ data class FilterAreaDto(
     val areas: List<FilterAreaDto>
 )
 
+@Deprecated(
+    message = "Используйте FilterAreaDto.toGeoArea() для поддержки иерархии стран и регионов",
+    replaceWith = ReplaceWith("this.toGeoArea()"),
+    level = DeprecationLevel.WARNING
+)
 fun FilterAreaDto.toDomain(): FilterArea {
     return FilterArea(
         id = id,
         name = name
+    )
+}
+
+fun FilterAreaDto.toGeoArea(): GeoArea = when {
+    parentId == null -> GeoArea.Country(
+        id = id,
+        name = name,
+        regions = areas.map { it.toGeoArea() as GeoArea.Region }
+    )
+
+    else -> GeoArea.Region(
+        id = id,
+        name = name,
+        countryId = parentId
     )
 }

--- a/app/src/main/java/ru/practicum/android/diploma/core/domain/model/FilterArea.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/core/domain/model/FilterArea.kt
@@ -1,5 +1,10 @@
 package ru.practicum.android.diploma.core.domain.model
 
+@Deprecated(
+    message = "Используйте GeoArea для поддержки иерархии стран и регионов",
+    replaceWith = ReplaceWith("GeoArea", "ru.practicum.android.diploma.core.domain.model.GeoArea"),
+    level = DeprecationLevel.WARNING
+)
 data class FilterArea(
     val id: Int,
     val name: String

--- a/app/src/main/java/ru/practicum/android/diploma/core/domain/model/GeoArea.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/core/domain/model/GeoArea.kt
@@ -1,0 +1,38 @@
+package ru.practicum.android.diploma.core.domain.model
+
+sealed class GeoArea {
+    abstract val id: Int
+    abstract val name: String
+
+    /**
+     * Модель страны (корневой элемент иерархии).
+     *
+     * Страна не имеет родителя и может содержать список регионов.
+     * Пример: Россия, США, Германия
+     *
+     * @property id Уникальный идентификатор страны
+     * @property name Название страны
+     * @property regions Список регионов внутри страны
+     */
+    data class Country(
+        override val id: Int,
+        override val name: String,
+        val regions: List<Region>
+    ) : GeoArea()
+
+    /**
+     * Модель региона (область, республика, край, город федерального значения).
+     *
+     * Регион всегда принадлежит какой-либо стране и не содержит вложенных областей.
+     * Пример: Республика Татарстан, Московская область, г. Санкт-Петербург
+     *
+     * @property id Уникальный идентификатор региона
+     * @property name Название региона
+     * @property countryId Идентификатор страны, в которой находится регион
+     */
+    data class Region(
+        override val id: Int,
+        override val name: String,
+        val countryId: Int
+    ) : GeoArea()
+}

--- a/app/src/test/java/ru/practicum/android/diploma/core/data/network/dto/DtoToDomainTest.kt
+++ b/app/src/test/java/ru/practicum/android/diploma/core/data/network/dto/DtoToDomainTest.kt
@@ -9,9 +9,11 @@ import org.koin.test.KoinTest
 import org.koin.test.get
 import ru.practicum.android.diploma.app.di.dataModule
 import ru.practicum.android.diploma.core.data.network.api.VacancyApi
+import ru.practicum.android.diploma.core.domain.model.GeoArea
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
-class VacancyDetailDtoToDomainTest : KoinTest {
+class DtoToDomainTest : KoinTest {
 
     private lateinit var api: VacancyApi
 
@@ -23,7 +25,7 @@ class VacancyDetailDtoToDomainTest : KoinTest {
     }
 
     @Test
-    fun toDomain() = runBlocking {
+    fun vacancyDtoToDomain() = runBlocking {
         val result = api.searchVacancies()
         val vacancyDto = result.items.first()
         val vacancy = vacancyDto.toDomain()
@@ -31,7 +33,20 @@ class VacancyDetailDtoToDomainTest : KoinTest {
         assertEquals(vacancyDto.description, vacancy.description)
         assertEquals(vacancyDto.address?.raw, vacancy.address?.fullAddress)
         assertEquals(vacancyDto.url, vacancy.website)
-        assertEquals(vacancyDto.contacts?.phones?.first()?.formatted, vacancy.contacts?.phoneNumbers?.first())
+        assertEquals(
+            vacancyDto.contacts?.phones?.first()?.formatted,
+            vacancy.contacts?.phoneNumbers?.first()
+        )
+    }
+
+    @Test
+    fun areaDtoToDomain() = runBlocking {
+        val result = api.getAreas()
+        val filterAreaDto = result.first()
+        val country = filterAreaDto.toGeoArea() as GeoArea.Country
+
+        assertEquals(country.id, country.regions.first().countryId)
+        assertNotEquals(country.name, country.regions.first().name)
     }
 
 }


### PR DESCRIPTION
**Новая модель GeoArea**
- Создан sealed class для представления географических областей с иерархией
- Country (страна) содержит список регионов и не имеет родителя
- Region (регион) привязан к стране через countryId и не содержит вложенных областей
- Обе модели имеют id и name

**Миграция с FilterArea**
- FilterArea помечен как @Deprecated с рекомендацией использовать GeoArea
- Указана замена с примером кода
- Функция toDomain() также помечена как deprecated

**Маппинг DTO → GeoArea**
- Добавлена функция toGeoArea() для преобразования FilterAreaDto в иерархическую модель
- Логика определения типа:
    - parentId == null → GeoArea.Country с преобразованными регионами
    - parentId != null → GeoArea.Region с сохранением countryId

**Примечание**
- Требуется обновить экраны фильтрации для использования новой модели GeoArea
- В дальнейшем FilterArea может быть полностью удалён