### PR TITLE
refactor/search

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/app/navigation/entries/TopLevelEntryProvider.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/app/navigation/entries/TopLevelEntryProvider.kt
@@ -2,7 +2,6 @@
 
 package ru.practicum.android.diploma.app.navigation.entries
 
-import android.content.Intent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.LaunchedEffect
@@ -10,7 +9,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
@@ -32,8 +30,8 @@ import ru.practicum.android.diploma.feature.search.presentation.SearchViewModel
 import ru.practicum.android.diploma.feature.search.ui.SearchScreen
 import ru.practicum.android.diploma.feature.team.presentation.TeamViewModel
 import ru.practicum.android.diploma.feature.team.ui.TeamScreen
-import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyDetailsUiEvent
 import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyDetailsViewModel
+import ru.practicum.android.diploma.feature.vacancy.ui.ObserveVacancyEvents
 import ru.practicum.android.diploma.feature.vacancy.ui.VacancyScreen
 
 fun topLevelEntryProvider(topLevelBackStack: TopLevelBackStack<NavKey>) = entryProvider<NavKey> {
@@ -93,33 +91,10 @@ fun topLevelEntryProvider(topLevelBackStack: TopLevelBackStack<NavKey>) = entryP
         }
 
         // обработка событий
-        LaunchedEffect(Unit) {
-            viewModel.events.collect { event ->
-                when (event) {
-                    is VacancyDetailsUiEvent.ShareVacancyLink -> {
-                        val intent = Intent(Intent.ACTION_SEND).apply {
-                            putExtra(Intent.EXTRA_TEXT, event.url)
-                            type = "text/plain"
-                        }
-                        context.startActivity(Intent.createChooser(intent, null))
-                    }
-
-                    is VacancyDetailsUiEvent.OpenEmailTo -> {
-                        val intent = Intent(Intent.ACTION_SENDTO).apply {
-                            data = "mailto:${event.email}".toUri()
-                        }
-                        context.startActivity(intent)
-                    }
-
-                    is VacancyDetailsUiEvent.OpenPhoneCall -> {
-                        val intent = Intent(Intent.ACTION_DIAL).apply {
-                            data = "tel:${event.phone}".toUri()
-                        }
-                        context.startActivity(intent)
-                    }
-                }
-            }
-        }
+        ObserveVacancyEvents(
+            events = viewModel.events,
+            context = context
+        )
 
         VacancyScreen(
             state = state,

--- a/app/src/main/java/ru/practicum/android/diploma/feature/filters/data/model/FiltersSettings.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/filters/data/model/FiltersSettings.kt
@@ -10,4 +10,10 @@ data class FiltersSettings(
     val salaryText: String? = null,
     val onlyWithSalary: Boolean? = null,
     val isStartSearch: Boolean = false
-)
+) {
+    val areaId: Int?
+        get() = region?.id ?: country?.id
+
+    val salary: Int?
+        get() = salaryText?.toIntOrNull()
+}

--- a/app/src/main/java/ru/practicum/android/diploma/feature/filters/domain/interactor/FiltersInteractor.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/filters/domain/interactor/FiltersInteractor.kt
@@ -12,7 +12,7 @@ interface FiltersInteractor {
 
     fun getFiltersSettings(): FiltersSettings?
 
-    fun saveFiltersSetting(settings: FiltersSettings)
+    fun saveFiltersSettings(settings: FiltersSettings)
 
     fun clearSettings()
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/filters/domain/interactor/FiltersInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/filters/domain/interactor/FiltersInteractorImpl.kt
@@ -32,7 +32,7 @@ class FiltersInteractorImpl(
         return repository.getFiltersSettings()
     }
 
-    override fun saveFiltersSetting(settings: FiltersSettings) {
+    override fun saveFiltersSettings(settings: FiltersSettings) {
         repository.saveFiltersSetting(settings)
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/feature/filters/presentation/viewmodel/FiltersViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/filters/presentation/viewmodel/FiltersViewModel.kt
@@ -124,8 +124,7 @@ class FiltersViewModel(private val interactor: FiltersInteractor) : ViewModel() 
 
     fun saveSettings(isStartSearch: Boolean) {
         if (filtersUiState.value.hasActiveFilters) {
-
-            interactor.saveFiltersSetting(
+            interactor.saveFiltersSettings(
                 FiltersSettings(
                     country = filtersUiState.value.workLocation.country,
                     region = filtersUiState.value.workLocation.region,

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/presentation/SearchUiState.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/presentation/SearchUiState.kt
@@ -7,5 +7,5 @@ data class SearchUiState(
     val vacancyState: VacancyState = VacancyState.Idle,
     val totalFound: Int = 0,
     val isNextPageLoading: Boolean = false,
-    val filtersSettings: FiltersSettings? = null
+    val filtersSettings: FiltersSettings = FiltersSettings()
 )

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/presentation/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/presentation/SearchViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import ru.practicum.android.diploma.core.domain.model.Vacancy
 import ru.practicum.android.diploma.core.domain.model.VacancyQuery
+import ru.practicum.android.diploma.feature.filters.data.model.FiltersSettings
 import ru.practicum.android.diploma.feature.filters.domain.interactor.FiltersInteractor
 import ru.practicum.android.diploma.feature.search.domain.interactor.SearchInteractor
 
@@ -32,10 +33,10 @@ class SearchViewModel(
     fun getFiltersSettings() = filtersInteractor.getFiltersSettings()?.let { filtersSettings ->
         _uiState.update { it.copy(filtersSettings = filtersSettings) }
         applyFiltersSettings()
-    } ?: _uiState.update { it.copy(filtersSettings = null) }
+    } ?: _uiState.update { it.copy(filtersSettings = FiltersSettings()) }
 
     private fun applyFiltersSettings() {
-        if (_uiState.value.filtersSettings?.isStartSearch == true) startSearch()
+        if (_uiState.value.filtersSettings.isStartSearch) startSearch()
     }
 
     fun startSearch(
@@ -146,10 +147,10 @@ class SearchViewModel(
     private fun String.toVacancyQuery(): VacancyQuery = _uiState.value.filtersSettings.let { filters ->
         VacancyQuery(
             text = this,
-            area = filters?.region?.id,
-            industry = filters?.industry?.id,
-            salary = filters?.salaryText?.toIntOrNull(),
-            onlyWithSalary = filters?.onlyWithSalary,
+            area = filters.areaId,
+            industry = filters.industry?.id,
+            salary = filters.salary,
+            onlyWithSalary = filters.onlyWithSalary,
             page = currentPage
         )
     }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/search/presentation/SearchViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/search/presentation/SearchViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,112 +27,125 @@ class SearchViewModel(
     private val loadedVacancies = mutableListOf<Vacancy>()
 
     private val _uiState = MutableStateFlow(SearchUiState())
-    val uiState = _uiState.asStateFlow()
+    val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
-    fun getFiltersSettings() {
-        val filtersSettings = filtersInteractor.getFiltersSettings()
-        filtersSettings?.let {
-            _uiState.update { it.copy(filtersSettings = filtersSettings) }
-            applyFiltersSettings()
-        } ?: _uiState.update { it.copy(filtersSettings = null) }
-    }
+    fun getFiltersSettings() = filtersInteractor.getFiltersSettings()?.let { filtersSettings ->
+        _uiState.update { it.copy(filtersSettings = filtersSettings) }
+        applyFiltersSettings()
+    } ?: _uiState.update { it.copy(filtersSettings = null) }
 
     private fun applyFiltersSettings() {
-        val currentText = uiState.value.searchText
-        val isStartSearch = uiState.value.filtersSettings?.isStartSearch
-        if (currentText.isNotEmpty() && isStartSearch == true) {
-            searchJob?.cancel()
-            searchJob = viewModelScope.launch {
-                performSearch(currentText)
-            }
-            filtersInteractor.saveFiltersSetting(
-                uiState.value.filtersSettings!!.copy(
-                    isStartSearch = false
-                )
-            )
-        }
+        if (_uiState.value.filtersSettings?.isStartSearch == true) startSearch()
     }
 
-    fun startSearch() {
-        searchJob?.cancel()
-        searchJob = viewModelScope.launch {
-            performSearch(uiState.value.searchText)
+    fun startSearch(
+        delayTimeMillis: Long? = null,
+        text: String = _uiState.value.searchText
+    ) = when {
+        latestSearchText.trim() == text.trim() -> {}
+
+        text.isNotBlank() -> {
+            searchJob?.cancel()
+            searchJob = viewModelScope.launch {
+                delayTimeMillis?.let { delay(it) }
+                performSearch(text)
+            }
         }
+
+        else -> _uiState.update { it.copy(vacancyState = VacancyState.Idle) }
     }
 
     private suspend fun performSearch(queryText: String) {
         if (queryText.isEmpty()) {
-            _uiState.value = _uiState.value.copy(vacancyState = VacancyState.Empty)
+            _uiState.update { it.copy(vacancyState = VacancyState.Empty) }
             return
         }
 
-        _uiState.value = _uiState.value.copy(vacancyState = VacancyState.Loading)
+        _uiState.update { it.copy(vacancyState = VacancyState.Loading) }
 
         loadedVacancies.clear()
         currentPage = 1
         maxPages = 1
 
-        val query = applyFiltersToQuery(queryText)
-
-        Log.d("PAGINATION0", "Requesting page = $currentPage")
-
+        val query = queryText.toVacancyQuery()
         val result = searchInteractor.searchVacancies(query)
+
+        Log.d(LOG_TAG, "performSearch(): Requesting $currentPage")
 
         result.fold(
             onSuccess = { (vacancies, totalPages, found) ->
-
                 loadedVacancies.addAll(vacancies)
                 maxPages = totalPages
                 totalFound = found
 
-                val newState =
-                    if (vacancies.isEmpty()) VacancyState.Empty else VacancyState.Content(loadedVacancies.toList())
-                _uiState.value = _uiState.value.copy(
-                    vacancyState = newState,
-                    totalFound = totalFound
-                )
-            },
-            onFailure = { error ->
+                _uiState.update {
+                    val newState = when {
+                        vacancies.isEmpty() -> VacancyState.Empty
+                        else -> VacancyState.Content(loadedVacancies)
+                    }
 
-                val code = error.message?.toIntOrNull()
-
-                val newState = when (code) {
-                    -1 -> VacancyState.ErrorInternet
-                    else -> VacancyState.ErrorFound
+                    it.copy(
+                        vacancyState = newState,
+                        totalFound = totalFound
+                    )
                 }
-
-                _uiState.value = _uiState.value.copy(
-                    vacancyState = newState
-                )
-            }
+            },
+            onFailure = { error -> handleSearchError(error) }
         )
     }
 
     // функция, которая будет использоваться при изменении текста чтобы не было конфликтов запросов
     fun onSearchTextChanged(text: String) {
-        _uiState.value = _uiState.value.copy(
-            searchText = text,
-        )
+        latestSearchText = _uiState.value.searchText
+        _uiState.update { it.copy(searchText = text) }
 
-        // дебаунс
-        if (latestSearchText == text) return
-        latestSearchText = text
-        searchJob?.cancel()
-        searchJob = viewModelScope.launch {
-            if (text.isNotEmpty()) {
-                delay(SEARCH_DEBOUNCE_DELAY)
-                performSearch(text)
-            } else {
-                _uiState.value = _uiState.value.copy(
-                    vacancyState = VacancyState.Idle,
-                )
-            }
+        startSearch(
+            text = text,
+            delayTimeMillis = SEARCH_DEBOUNCE_DELAY
+        )
+    }
+
+    fun loadNextPage() {
+        if (_uiState.value.isNextPageLoading || currentPage >= maxPages) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isNextPageLoading = true) }
+
+            currentPage++
+
+            val query = _uiState.value.searchText.toVacancyQuery()
+            val result = searchInteractor.searchVacancies(query)
+
+            Log.d(LOG_TAG, "loadNextPage(): Loading page $currentPage")
+
+            result.fold(
+                onSuccess = { (vacancies, totalPages, _) ->
+                    loadedVacancies.addAll(vacancies)
+                    _uiState.update { it.copy(vacancyState = VacancyState.Content(loadedVacancies)) }
+                    maxPages = totalPages
+                },
+                onFailure = { error -> handleSearchError(error) }
+            )
+            _uiState.update { it.copy(isNextPageLoading = false) }
         }
     }
 
-    private fun applyFiltersToQuery(query: String): VacancyQuery = _uiState.value.filtersSettings.let { filters ->
+    private fun handleSearchError(error: Throwable) {
+        val code = error.message?.toIntOrNull()
+
+        _uiState.update {
+            val newState = when (code) {
+                -1 -> VacancyState.ErrorInternet
+                else -> VacancyState.ErrorFound
+            }
+
+            it.copy(vacancyState = newState)
+        }
+    }
+
+    private fun String.toVacancyQuery(): VacancyQuery = _uiState.value.filtersSettings.let { filters ->
         VacancyQuery(
-            text = query,
+            text = this,
             area = filters?.region?.id,
             industry = filters?.industry?.id,
             salary = filters?.salaryText?.toIntOrNull(),
@@ -140,54 +154,8 @@ class SearchViewModel(
         )
     }
 
-    fun loadNextPage() {
-        val queryText = _uiState.value.searchText
-
-        if (queryText.isEmpty()) return
-        if (_uiState.value.isNextPageLoading || currentPage >= maxPages) return
-
-        viewModelScope.launch {
-            _uiState.update { it.copy(isNextPageLoading = true) }
-
-            currentPage++
-
-            val query = applyFiltersToQuery(queryText)
-
-            Log.d("PAGINATION", "Requesting page = $currentPage")
-
-            val result = searchInteractor.searchVacancies(query)
-
-            result.fold(
-                onSuccess = { (vacancies, totalPages, _) ->
-
-                    loadedVacancies.addAll(vacancies)
-
-                    _uiState.update {
-                        it.copy(
-                            vacancyState = VacancyState.Content(loadedVacancies.toList())
-                        )
-                    }
-
-                    maxPages = totalPages
-                },
-                onFailure = { error ->
-
-                    val code = error.message?.toIntOrNull()
-
-                    val newState = when (code) {
-                        -1 -> VacancyState.ErrorInternet
-                        else -> VacancyState.ErrorFound
-                    }
-
-                    _uiState.update { it.copy(vacancyState = newState) }
-
-                }
-            )
-            _uiState.update { it.copy(isNextPageLoading = false) }
-        }
-    }
-
     companion object {
+        private val LOG_TAG = SearchViewModel::class.simpleName.toString()
         private const val SEARCH_DEBOUNCE_DELAY = 2000L
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyEventHandler.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/feature/vacancy/ui/VacancyEventHandler.kt
@@ -1,0 +1,50 @@
+package ru.practicum.android.diploma.feature.vacancy.ui
+
+import android.content.Context
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.core.net.toUri
+import kotlinx.coroutines.flow.Flow
+import ru.practicum.android.diploma.feature.vacancy.presentation.VacancyDetailsUiEvent
+
+@Composable
+fun ObserveVacancyEvents(
+    events: Flow<VacancyDetailsUiEvent>,
+    context: Context
+) {
+    LaunchedEffect(Unit) {
+        events.collect { event ->
+            handleVacancyEvent(event, context)
+        }
+    }
+}
+
+private fun handleVacancyEvent(
+    event: VacancyDetailsUiEvent,
+    context: Context
+) {
+    when (event) {
+        is VacancyDetailsUiEvent.ShareVacancyLink -> {
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                putExtra(Intent.EXTRA_TEXT, event.url)
+                type = "text/plain"
+            }
+            context.startActivity(Intent.createChooser(intent, null))
+        }
+
+        is VacancyDetailsUiEvent.OpenEmailTo -> {
+            val intent = Intent(Intent.ACTION_SENDTO).apply {
+                data = "mailto:${event.email}".toUri()
+            }
+            context.startActivity(intent)
+        }
+
+        is VacancyDetailsUiEvent.OpenPhoneCall -> {
+            val intent = Intent(Intent.ACTION_DIAL).apply {
+                data = "tel:${event.phone}".toUri()
+            }
+            context.startActivity(intent)
+        }
+    }
+}


### PR DESCRIPTION
- Поиск не запускается для пустого запроса, а переводит экран в состояние `Idle`
- Улучшена обработка дебаунса: сравнение `trim()` поискового запроса позволяет игнорировать изменения только пробелов
- Устранено избыточное сохранение настроек фильтров при каждом старте поиска (удалён лишний вызов `saveFiltersSettings`)
- Поиск вакансий теперь учитывает выбранную страну, даже если регион не указан